### PR TITLE
Allow multiple events to be bound to onbeforeunload even

### DIFF
--- a/jquery/jquery.informant.js
+++ b/jquery/jquery.informant.js
@@ -5,11 +5,11 @@
 		
 		var inform = false;
 		
-		window.onbeforeunload = function() {
+		$(window).on('beforeunload', function() {
 			if(inform) {
 				return options.message;
 			}
-		};
+		});
 		
 		return this.each(function() {
 			var form = $(this);


### PR DESCRIPTION
Using the raw assignment for window.onbeforeunload prevents other events from being bound to that event.  Using jquery's "on" method should alleviate this issue as well as any event binding issues with IE.
